### PR TITLE
Adjust subuid/gid range to a valid range

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ To use it, install lxd and initialize it using `lxd init`. When prompted, answer
 
 0. Before you can fire up your lxc container, you have to make sure to create `/etc/subuid` and `/etc/subgid` with the following entries:
 
-       root:1000000:1000000000
-       <youruserid>:1000000:1000000000
+       root:100000:1000000000
+       <youruserid>:100000:1000000000
 
    Run `systemctl restart lxd` to have LXD detect your new maps.
 


### PR DESCRIPTION
Even though the container is privileged, with the current ranges of 1,000,000:1,000,000,000 the folders /proc and /sys belong to nobody which would be a sign of an unprivileged container. The problem seems to be fixed if the range starts at 100,000.